### PR TITLE
[FIX] Time window attack summarization

### DIFF
--- a/server/cron/summarize.ts
+++ b/server/cron/summarize.ts
@@ -10,7 +10,7 @@ export default defineCronHandler(
   async () => {
     try {
       const now = new Date();
-      const randomOffset = Math.floor(Math.random() * 24 * 60 * 60 * 1000);
+      const randomOffset = Math.floor(crypto.getRandomValues(new Float64Array(1))[0] * 24 * 60 * 60 * 1000);
       const yesterday = new Date(now.getTime() - randomOffset);
       yesterday.setHours(0, 0, 0, 0);
 

--- a/server/cron/summarize.ts
+++ b/server/cron/summarize.ts
@@ -9,11 +9,11 @@ export default defineCronHandler(
   async () => {
     try {
       const now = new Date();
-      const yesterday = new Date(now);
-      yesterday.setDate(yesterday.getDate() - 1);
+      const randomOffset = Math.floor(Math.random() * 24 * 60 * 60 * 1000);
+      const yesterday = new Date(now.getTime() - randomOffset);
       yesterday.setHours(0, 0, 0, 0);
 
-      const today = new Date(now);
+      const today = new Date(now.getTime() - randomOffset + 24 * 60 * 60 * 1000);
       today.setHours(0, 0, 0, 0);
 
       const heartbeatsToSummarize = await prisma.heartbeat.findMany({


### PR DESCRIPTION
Closes #23 

Implements a random offset between 0-24 hours to make it unpredictable for attackers to know exactly when the window changes.

@obvTiger please review