### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
   prepare:
     name: Prepare Docker Metadata
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Potential fix for [https://github.com/0PandaDEV/Ziit/security/code-scanning/2](https://github.com/0PandaDEV/Ziit/security/code-scanning/2)

To fix the issue, you should add an explicit `permissions` block to the `prepare` job in `.github/workflows/build.yml`. This block should use the least privilege required for the job's steps. Since the job mainly checks out code and extracts Docker metadata, `contents: read` is generally sufficient and is the recommended minimal starting point. You should insert this block between `runs-on: ubuntu-latest` and `outputs:` to ensure it applies to the job configuration. No additional imports or external libraries are required; this is purely a declarative change to the YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
